### PR TITLE
chore(renovate): fix lookup for private ch.dboeckli Maven packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -64,6 +64,18 @@
             "enabled": false
         },
         {
+            "description": "Private dboeckli Maven packages on GitHub Packages",
+            "matchDatasources": [
+                "maven"
+            ],
+            "matchPackageNames": [
+                "/^ch\\.dboeckli\\./"
+            ],
+            "registryUrls": [
+                "https://maven.pkg.github.com/dboeckli/spring-6-rest-mvc-api"
+            ]
+        },
+        {
             "matchCategories": [
                 "docker"
             ],


### PR DESCRIPTION
Fixes the Renovate dependency lookup warning for `ch.dboeckli.guru.springframework:spring-6-rest-mvc-api` (no-result) by overriding `registryUrls` for private `ch.dboeckli.*` Maven packages to the canonical GitHub Packages URL of the publishing repo `spring-6-rest-mvc-api`.

Reference: `spring-6-rest-mvc` PR #222.